### PR TITLE
Added few more variables to akamai.tf

### DIFF
--- a/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/akamai.tf
+++ b/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/akamai.tf
@@ -13,12 +13,17 @@ locals {
 module "akamai_property" {
   source             = "./modules/property"
   group_name         = "My Group"
-  product_id         = "Fresca"
+  product_id         = "prd_Fresca"
   cp_code_name       = "tf-demo.host.com"
   edge_hostname      = local.edge_hostname
   property_name      = local.global_name
   property_hostnames = local.hostnames
   email              = local.email
+  origin_server      = "origin-tf.aiqbal.com"
+  certificate_enrollment_id = 123456
+  cert_provisioning_type = "CPS_MANAGED"
+  activate_in_staging = true
+  activate_in_production = false
 }
 
 module "akamai_edgedns_records" {
@@ -41,7 +46,7 @@ module "security" {
   hostnames   = local.hostnames
   name        = "tf-demo-appsec-configuration"
   description = "Spin up configuration via Terraform"
-  contract_id = module.akamai_property.contract_id
+  contract_id = trimprefix(module.akamai_property.contract_id, "ctr_")
   group_name  = "My Group"
   depends_on = [
     module.akamai_property
@@ -52,7 +57,7 @@ module "activate-security" {
   source              = "./modules/activate-security"
   name                = "tf-demo-appsec-configuration"
   config_id           = module.security.config_id
-  network             = "PRODUCTION"
+  network             = "STAGING"
   notification_emails = [local.email]
   note                = "AppSec configuration deployed with the Akamai Terraform Provider."
   depends_on = [

--- a/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/modules/property/property.tf
+++ b/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/modules/property/property.tf
@@ -17,6 +17,7 @@ resource "akamai_edge_hostname" "my_edge_hostname" {
   group_id      = data.akamai_contract.contract.group_id
   ip_behavior   = "IPV6_COMPLIANCE"
   edge_hostname = var.edge_hostname
+  certificate   = var.certificate_enrollment_id
 }
 
 
@@ -24,14 +25,14 @@ resource "akamai_property" "my_property" {
   name        = var.property_name
   contract_id = data.akamai_contract.contract.id
   group_id    = data.akamai_contract.contract.group_id
-  product_id  = "prd_Fresca"
+  product_id  = var.product_id
 
   dynamic "hostnames" {
     for_each = var.property_hostnames
     content {
       cname_from             = hostnames.value
       cname_to               = akamai_edge_hostname.my_edge_hostname.edge_hostname
-      cert_provisioning_type = "DEFAULT"
+      cert_provisioning_type = var.cert_provisioning_type
     }
   }
 
@@ -44,7 +45,7 @@ resource "akamai_property_activation" "my_property-staging" {
   contact                        = [var.email]
   version                        = akamai_property.my_property.latest_version
   network                        = "STAGING"
-  auto_acknowledge_rule_warnings = true
+  auto_acknowledge_rule_warnings = var.activate_in_staging
 }
 
 resource "akamai_property_activation" "my_property-production" {
@@ -52,7 +53,7 @@ resource "akamai_property_activation" "my_property-production" {
   contact                        = [var.email]
   version                        = akamai_property.my_property.latest_version
   network                        = "PRODUCTION"
-  auto_acknowledge_rule_warnings = true
+  auto_acknowledge_rule_warnings = var.activate_in_production
 
   compliance_record {
     noncompliance_reason_no_production_traffic {

--- a/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/modules/property/variables.tf
+++ b/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/modules/property/variables.tf
@@ -19,6 +19,21 @@ variable "edge_hostname" {
   description = "Akamai Edge Hostname"
 }
 
+variable "origin_server" {
+  type        = string
+  description = "Origin Server"
+}
+
+variable "activate_in_staging" {
+  type        = bool
+  description = "Activate Staging"
+}
+
+variable "activate_in_production" {
+  type        = bool
+  description = "Activate Production"
+}
+
 variable "property_name" {
   type        = string
   description = "Akamai Property/Configuration Name"
@@ -33,3 +48,14 @@ variable "email" {
   type        = string
   description = "Notification email"
 }
+
+variable "certificate_enrollment_id" {
+  type        = number
+  description = "Certificate Enrollment ID"
+}
+
+variable "cert_provisioning_type" {
+  type        = string
+  description = "Certificate Provisioning Type"
+}
+

--- a/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/modules/security/protections.tf
+++ b/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/modules/security/protections.tf
@@ -20,7 +20,7 @@ resource "akamai_appsec_ip_geo_protection" "my_policy" {
 resource "akamai_appsec_malware_protection" "my_policy" {
   config_id          = akamai_appsec_configuration.config.config_id
   security_policy_id = akamai_appsec_ip_geo_protection.my_policy.security_policy_id
-  enabled            = true
+  enabled            = false
 }
 
 resource "akamai_appsec_rate_protection" "my_policy" {

--- a/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/modules/security/selected-hostnames.tf
+++ b/Onboardig/DeclarativeRuleTree/1_pm_secure_by_default_appsec/modules/security/selected-hostnames.tf
@@ -1,5 +1,0 @@
-resource "akamai_appsec_selected_hostnames" "hostnames" {
-  config_id = akamai_appsec_configuration.config.config_id
-  hostnames = var.hostnames
-  mode      = "REPLACE"
-}


### PR DESCRIPTION
1. akamai.tf is more flexible with more variables.

  - added prd_ prefix to product_id variable
  - added variables allow certificate enrollment that is needed for edgekey. 
  - variables to control delivery config activation in staging and prod

2. fixed a bug where security config does not like prefix for contract id
3. automating security config activation on staging only one can have option to test in staging and then push to prod
4. akamai_appsec_malware_protection resource does not seem to allow enable with TF
5. removed akamai_appsec_selected_hostnames as it is a deprecated resource